### PR TITLE
Fix tag

### DIFF
--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -837,7 +837,7 @@ jobs:
           }
 
           DEPLOY_ENV_TARGET=$(
-            echo ${{ needs.build_and_push.outputs.version }} | grep -Eo 'staging|develop|ire|india|mumbaistg' || echo 'production'
+            echo ${{ needs.build_and_push.outputs.version }} | grep -Eo 'mumbai-staging|staging|develop|ireland|mumbai' || echo 'production'
           )
 
           echo "Target environment: ${DEPLOY_ENV_TARGET}"

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -836,7 +836,9 @@ jobs:
             [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
           }
 
-          DEPLOY_ENV_TARGET="${{ inputs.default_environment }}"
+          DEPLOY_ENV_TARGET=$(
+            echo ${{ needs.build_and_push.outputs.version }} | grep -Eo 'staging|develop|ire|india|mumbaistg' || echo 'production'
+          )
 
           echo "Target environment: ${DEPLOY_ENV_TARGET}"
 

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -836,9 +836,7 @@ jobs:
             [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
           }
 
-          DEPLOY_ENV_TARGET=$(
-            echo ${{ needs.build_and_push.outputs.version }} | grep -Eo 'staging|develop' || echo 'production'
-          )
+          DEPLOY_ENV_TARGET="${{ inputs.default_environment }}"
 
           echo "Target environment: ${DEPLOY_ENV_TARGET}"
 


### PR DESCRIPTION
# Support ireland and mumbai environments in reusable workflow

## Summary

This PR adds support for the  `*-mumbai-staging` , `*-ireland` and `*-mumbai` tags in the reusable workflow environment detection logic.

The workflow now correctly maps these tags to their corresponding environment folders without using abbreviated tag names.

## Changes

- Added support for:
  - `*-ireland`
  - `*-mumbai`
  - `*-mumbai-staging`
- Updated environment detection logic to include `ireland` and `mumbai`
- Ensured the correct manifest folders are used during deployment
- Removed dependency on abbreviated tags (e.g. `*-ire`, `*-india`, `*-mum`)

## Tag Triggers Updated

The workflow now accepts:

- `*.*.*-mumbai-staging`
- `*.*.*-mumbai`
- `*.*.*-ireland`
- `*.*.*-staging`

## Validation

Successfully tested with:

- `0.0.0-mumbai`
- `0.0.0-mumbai-staging`
- `0.0.0-ireland`

All builds and deployments completed successfully.

## Notes

Abbreviated tag formats are no longer supported to avoid ambiguity and future naming conflicts.

<img width="1285" height="611" alt="bom " src="https://github.com/user-attachments/assets/ae7c494a-2d60-46b2-9a90-30ecec4404da" />
